### PR TITLE
Update infrastructure providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,7 @@ Haskell.org uses many service providers for its infrastructure.
 * [CloudFlare](https://www.cloudflare.com/) provides DNS management, Anti-DDoS, and high-grade frontend SSL and caching for most of Haskell.org
 * Status.io powers https://status.haskell.org, and lets us easily tell you when we broke something.
 * [DreamHost](https://www.dreamhost.com/) supports Haskell.org by providing free and unlimited object storage and bandwidth via DreamObjects, which we use to stash logs, perform backups, and generally host all kinds of long-term content that we might need.
-
+* [SimSpace](https://simspace.com/) hosts some of the GHC CI infrastructure for ARM.
+* [Discourse](https://www.discourse.org/) hosts <https://discourse.haskell.org/>.
+* [DigitalOcean](https://www.digitalocean.com/)
+* [OpenCape](https://www.opencape.org/)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ You can contact the current team at any time with an email to admin@haskell.org,
 ### Infrastructure providers
 Haskell.org uses many service providers for its infrastructure.
 
-* [Packet.com](https://www.packet.com/) provides compute, storage, and networking resources, powering almost all of Haskell.org in several regions around the world. 
 * [Fastly](https://www.fastly.com/) provides low latency access for all of Haskell.org's downloads and highest traffic services, including the primary Hackage server, and Haskell Platform/GHC downloads.
 * [CloudFlare](https://www.cloudflare.com/) provides DNS management, Anti-DDoS, and high-grade frontend SSL and caching for most of Haskell.org
 * Status.io powers https://status.haskell.org, and lets us easily tell you when we broke something.

--- a/servers.md
+++ b/servers.md
@@ -1,6 +1,6 @@
 # Haskell Infra Core Servers List
 
-## www-combo-origin.haskell.org (packet)
+## www-combo-origin.haskell.org
 
 Almost all content is static except for the wiki.
 
@@ -27,7 +27,7 @@ Hosts the main haskell.org website and the following subsites
 
 Also hosts a number of subdomains such as: archives.haskell.org, hoogle.haskell.org, downloads.haskell.org, wiki.haskell.org, summer.haskell.org, pvp.haskell.org
 
-## misc-services-origin.haskell.org (packet)
+## misc-services-origin.haskell.org
 
 Hosts nonstatic content and services
 
@@ -35,11 +35,11 @@ Hosts nonstatic content and services
 * postfix (half migrated)
 * hoogle service
 
-## hackage-origin.haskell.org (packet)
+## hackage-origin.haskell.org
 
 Hosts hackage
 
-## docbuilder.hackage.haskell.org (packet)
+## docbuilder.hackage.haskell.org
 
 Hosts the docbuilder (maintained by gbaz centrally)
 
@@ -47,6 +47,6 @@ Hosts the docbuilder (maintained by gbaz centrally)
 
 Hosts the build matrix (maintained by hvr)
 
-## Various ghc ci boxes (packet)
+## Various ghc ci boxes
 
 ghc-arm-2, ghc-ci-1, ghc-ci-m1, etc. (in flux)


### PR DESCRIPTION
Remove references to Packet.com and add new infrastructure providers.